### PR TITLE
OCI - Added variables for OCPU, memory and boot disk size

### DIFF
--- a/oci/oci-generic.tf
+++ b/oci/oci-generic.tf
@@ -31,6 +31,24 @@ variable "oci_instance_shape" {
   description              = "The size of the compute instance, only certain sizes are free-tier"
 }
 
+variable "oci_instance_diskgb" {
+  type                     = string
+  description              = "Size of system boot disk, in gb"
+  default                  = 47
+}
+
+variable "oci_instance_memgb" {
+  type                     = string
+  description              = "Memory GB(s) for instance"
+  default                  = 1
+}
+
+variable "oci_instance_ocpus" {
+  type                     = string
+  description              = "Oracle CPUs for instance"
+  default                  = 1
+}
+
 variable "ssh_key" {
   type                     = string
   description              = "Public SSH key for SSH to compute instance, user is ubuntu"

--- a/oci/oci-instance.tf
+++ b/oci/oci-instance.tf
@@ -42,10 +42,15 @@ resource "oci_core_instance" "ph-instance" {
     display_name            = "${var.ph_prefix}-nic"
     subnet_id               = oci_core_subnet.ph-subnet.id
   }
+  shape_config {
+    memory_in_gbs           = var.oci_instance_memgb
+    ocpus                   = var.oci_instance_ocpus
+  }
   source_details {
     source_id               = data.oci_core_image.ph-image.id
     source_type             = "image"
     kms_key_id              = oci_kms_key.ph-kms-disk-key.id
+    boot_volume_size_in_gbs = var.oci_instance_diskgb
   }
   metadata = {
     ssh_authorized_keys       = var.ssh_key

--- a/oci/oci.tfvars
+++ b/oci/oci.tfvars
@@ -50,7 +50,16 @@ client_cidrs = []
 
 oci_region = "us-ashburn-1"
 oci_adnumber = 1
+
+# By default Cloudblock for OCI is configured to use the Always Free tier included Micro (AMD) instance
+# A different shape can be specified here
 oci_instance_shape = "VM.Standard.E2.1.Micro"
+
+# If required, the instance boot volume can be changed here. By default the "VM.Standard.E2.1.Micro" instance uses a 47GB boot volume
+# The Always Free tier includes 200GB of block volume storage across all instances
+oci_instance_diskgb = 47
+oci_instance_ocpus = 1
+oci_instance_memgb = 1
 
 # OCI's managed Ubuntu 18.04 Minimal image, might need to be changed in the future as images are updated periodically
 # See https://docs.cloud.oracle.com/en-us/iaas/images/ubuntu-1804/

--- a/oci/oci.tfvars
+++ b/oci/oci.tfvars
@@ -51,13 +51,14 @@ client_cidrs = []
 oci_region = "us-ashburn-1"
 oci_adnumber = 1
 
-# By default Cloudblock for OCI is configured to use the Always Free tier included Micro (AMD) instance
-# A different shape can be specified here
+# By default Cloudblock for OCI is configured to use the Always Free tier included Micro (AMD) instance - a different shape can be specified here
 oci_instance_shape = "VM.Standard.E2.1.Micro"
 
-# If required, the instance boot volume can be changed here. By default the "VM.Standard.E2.1.Micro" instance uses a 47GB boot volume
-# The Always Free tier includes 200GB of block volume storage across all instances
-oci_instance_diskgb = 47
+# If required, the instance boot volume can be changed here. By default the "VM.Standard.E2.1.Micro" instance uses a 50GB boot volume
+# The Always Free tier includes 200GB of block volume storage across all instances in your tenancy
+oci_instance_diskgb = 50
+
+# Default OCPUs and Memory set Always Free tier included Micro instance - can be adjusted here if other shape specified above
 oci_instance_ocpus = 1
 oci_instance_memgb = 1
 


### PR DESCRIPTION
Used oci-generic.tf, oci-instance.tf & oci.tfvars from chadgeary/cloudoffice to allow change of VM shape, OCPU count, memory & boot disk size. To allow use with OCI flex instances