### PR TITLE
Use dependences from installed Azure collection

### DIFF
--- a/azure/az-custom_data.tpl
+++ b/azure/az-custom_data.tpl
@@ -36,11 +36,11 @@ apt-get update
 # Install pip3 git and python packages
 DEBIAN_FRONTEND=noninteractive apt-get -y install python3-pip git
 pip3 install --upgrade pip
-pip3 install ansible[azure]
+pip3 install --upgrade ansible[azure]
 # And the collection
-ansible-galaxy collection install azure.azcollection
+ansible-galaxy collection install azure.azcollection --force
 # And the requirements
-pip3 install -r ~/.ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt
+pip3 install --upgrade -r ~/.ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt
 # Make the project directory
 mkdir -p /opt/cloudblock
 # Clone project

--- a/azure/az-custom_data.tpl
+++ b/azure/az-custom_data.tpl
@@ -40,10 +40,7 @@ pip3 install ansible[azure]
 # And the collection
 ansible-galaxy collection install azure.azcollection
 # And the requirements
-rm -f requirements-azure.txt
-wget https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements-azure.txt
-# Install the requirements
-pip3 install -r requirements-azure.txt
+pip3 install -r ~/.ansible/collections/ansible_collections/azure/azcollection/requirements-azure.txt
 # Make the project directory
 mkdir -p /opt/cloudblock
 # Clone project


### PR DESCRIPTION
This PR resolves https://github.com/chadgeary/cloudblock/issues/30, where the dependencies being installed for the Azure Ansible collection are different than what the collection expects.

For detail, see https://github.com/ansible-collections/azure/issues/715#issuecomment-1001807637.