### PR TITLE
Notes for deploying cloudblock on a Proxmox LXC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *-setup-*.sh
 *-init-*.yml
 *.swp
+.DS_Store


### PR DESCRIPTION
Please don't accept this pull request until we figure things out. Nevertheless, here are my notes so far for creating the LXC, everything after the container setup is the same as the local ubuntu install. Note that I also changed the playbook lines 179 to the following, but did not add this change to the pull request since we're still testing:
```
    - name: Cloudflared image
      ansible.builtin.shell: |
        docker build --security-opt apparmor:unconfined -t cloudflared_doh .
      args:
        chdir: /opt/cloudflared/
```