### PR TITLE
Typo correction in az-output.tf

### DIFF
--- a/azure/az-output.tf
+++ b/azure/az-output.tf
@@ -34,7 +34,7 @@ sudo systemctl start cloudblock-ansible-state.service
 #############
 
 # To destroy the project via terraform
-terraform destroy -var-file="gcp.tfvars"
+terraform destroy -var-file="az.tfvars"
 
 OUTPUT
 }


### PR DESCRIPTION
Typo fix for terraform destroy command. 
Previously pointed to "gcp.tfvars" corrected to "az.tfvars"