### PR TITLE
oops

### DIFF
--- a/etc/aws-two-instances/playbooks/cloudblock_aws_amd64.yml
+++ b/etc/aws-two-instances/playbooks/cloudblock_aws_amd64.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/etc/aws-two-instances/playbooks/cloudblock_aws_arm.yml
+++ b/etc/aws-two-instances/playbooks/cloudblock_aws_arm.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_amd64.yml
+++ b/playbooks/cloudblock_amd64.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_arm64.yml
+++ b/playbooks/cloudblock_arm64.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_aws_amd64.yml
+++ b/playbooks/cloudblock_aws_amd64.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_aws_arm.yml
+++ b/playbooks/cloudblock_aws_arm.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_azure.yml
+++ b/playbooks/cloudblock_azure.yml
@@ -9,7 +9,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_do.yml
+++ b/playbooks/cloudblock_do.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_gcp.yml
+++ b/playbooks/cloudblock_gcp.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_oci_no_encryption.yml
+++ b/playbooks/cloudblock_oci_no_encryption.yml
@@ -9,7 +9,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_raspbian.yml
+++ b/playbooks/cloudblock_raspbian.yml
@@ -8,7 +8,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query

--- a/playbooks/cloudblock_scw.yml
+++ b/playbooks/cloudblock_scw.yml
@@ -7,7 +7,7 @@
 
     - name: Custom facts
       ansible.builtin.set_fact:
-        url_from_doh:
+        url_from_doh_provider:
           adguard: https://dns.adguard.com/dns-query
           cloudflare: https://cloudflare-dns.com/dns-query
           cloudflare-security: https://security.cloudflare-dns.com/dns-query


### PR DESCRIPTION
fixes the playbooks (other than oci) that had an incorrectly referenced var for the doh url map