### PR TITLE
Feature: Automatic Assignment of IPv4 Address from Local Machine

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -171,13 +171,16 @@ Edit the vars file (aws.tfvars) to customize the deployment, especially:
 # a public SSH key for SSH access to the instance via user `ubuntu`.
 # cat ~/.ssh/id_rsa.pub
 
-# mgmt_cidr
-# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
-# deploying from home? This should be your public IP address with a /32 suffix.
-
 # kms_manager
 # The AWS username (not root) granted access to read the Wireguard VPN configuration files in S3.
 ```
+
+>**Note**: Modify `mgmt_cidr` only if you must allow access to the deployed resources from a machine that is **not** the machine that is deploying this code *OR* if you must allow-list IPv6.
+```
+# mgmt_cidr
+# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
+# deploying from home? This should be your public IP address with a /32 suffix.
+``` 
 
 # Post-Deployment
 - Wait for Ansible Playbook, watch [AWS State Manager](https://console.aws.amazon.com/systems-manager/state-manager)
@@ -203,9 +206,6 @@ wsl
 
 # Change to the project directory
 cd ~/cloudblock/aws/
-
-# Update the mgmt_cidr variable - be sure to replace change_me with your public IP address
-sed -i -e "s#^mgmt_cidr = .*#mgmt_cidr = \"change_me/32\"#" aws.tfvars
 
 # Rerun terraform apply, terraform will update the cloud firewall rules
 terraform apply -var-file="aws.tfvars"

--- a/azure/README.md
+++ b/azure/README.md
@@ -155,11 +155,14 @@ Edit the vars file (az.tfvars) to customize the deployment, especially:
 # ssh_key
 # A public SSH key for access to the compute instance via SSH, with user ubuntu.
 # cat ~/.ssh/id_rsa.pub
-
-# mgmt_cidr
-# an IP range granted webUI, instance SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
-# deploying from home? This should be your public IP address with a /32 suffix. 
 ```
+
+>**Note**: Modify `mgmt_cidr` only if you must allow access to the deployed resources from a machine that is **not** the machine that is deploying this code *OR* if you must allow-list IPv6.
+```
+# mgmt_cidr
+# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
+# deploying from home? This should be your public IP address with a /32 suffix.
+``` 
 
 # Deploy
 ```
@@ -196,9 +199,6 @@ wsl
 
 # Change to the project directory
 cd ~/cloudblock/azure/
-
-# Update the mgmt_cidr variable - be sure to replace change_me with your public IP address
-sed -i -e "s#^mgmt_cidr = .*#mgmt_cidr = \"change_me/32\"#" az.tfvars
 
 # Rerun terraform apply, terraform will update the cloud firewall rules
 terraform apply -var-file="az.tfvars"

--- a/azure/az-generic.tf
+++ b/azure/az-generic.tf
@@ -143,3 +143,9 @@ variable "vpn_traffic" {
   type        = string
   description = "dns or all, sets the Wireguard VPN client configuration to route only dns traffic or all traffic through the VPN."
 }
+
+# IPv4 address for the machine executing the TF code
+
+data "http" "execution_ip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/azure/az.tfvars
+++ b/azure/az.tfvars
@@ -1,7 +1,9 @@
 ## COMMON ##
 ph_password = "changeme"
 ssh_key     = "ssh-rsa AAAAchangeme_changeme_changeme_changemexUL5UY4ko4tynCSp7zgVpot/OppqdHl5J+DYhNubm8ess6cugTustUZoDmJdo2ANQENeBUNkBPXUnMO1iulfNb6GnwWJ0Z5TRRLGSu1gya2wMLeo1rBJFcb6ZgVLMVHiKgwBy/svUQreR8R+fpVW+Q4rx6RSAltLROUONn0SF2BvvJUueqxpAIaA2rU4MSI69P"
-mgmt_cidr   = "1.2.3.4/32"
+
+# This default value is set to IPv4 address of the machine executing the TF code. If you have other needs, such as different IPs between the machine executing TF code and the location that will use the pihole, then you must manually override this declaration
+mgmt_cidr = "${chomp(data.http.execution_ip.request_body)}/32"
 
 # The number of wireguard peer configurations to generate / store - 1 per device
 wireguard_peers = 20

--- a/do/README.md
+++ b/do/README.md
@@ -166,13 +166,16 @@ Edit the vars file (do.tfvars) to customize the deployment, especially:
 # A public SSH key for access to the compute instance via SSH, with user ubuntu.
 # cat ~/.ssh/id_rsa.pub
 
-# mgmt_cidr
-# an IP range granted webUI, instance SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
-# deploying from home? This should be your public IP address with a /32 suffix. 
-
 # do_token, do_storageaccessid, and do_storagesecretkey
 # credentials generated via the Digital Ocean WebUI (API page)
 ```
+
+>**Note**: Modify `mgmt_cidr` only if you must allow access to the deployed resources from a machine that is **not** the machine that is deploying this code *OR* if you must allow-list IPv6.
+```
+# mgmt_cidr
+# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
+# deploying from home? This should be your public IP address with a /32 suffix.
+``` 
 
 # Deploy
 ```
@@ -214,9 +217,6 @@ wsl
 
 # Change to the project directory
 cd ~/cloudblock/do/
-
-# Update the mgmt_cidr variable - be sure to replace change_me with your public IP address
-sed -i -e "s#^mgmt_cidr = .*#mgmt_cidr = \"change_me/32\"#" do.tfvars
 
 # Rerun terraform apply, terraform will update the cloud firewall rules
 terraform apply -var-file="do.tfvars"

--- a/do/do-generic.tf
+++ b/do/do-generic.tf
@@ -139,3 +139,9 @@ variable "dns_novpn" {
   type        = number
   description = "Enable (1) or disable (0) exposuring of port 53 (tcp and udp), DNS via pihole, to mgmt_cidr"
 }
+
+# IPv4 address for the machine executing the TF code
+
+data "http" "execution_ip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/do/do.tfvars
+++ b/do/do.tfvars
@@ -1,7 +1,10 @@
 ## COMMON ##
 ph_password = "changeme1"
 ssh_key     = "ssh-rsa AAAAB3replace_me_replace_me_replace_me"
-mgmt_cidr   = "1.2.3.4/32"
+
+
+# This default value is set to IPv4 address of the machine executing the TF code. If you have other needs, such as different IPs between the machine executing TF code and the location that will use the pihole, then you must manually override this declaration
+mgmt_cidr = "${chomp(data.http.execution_ip.request_body)}/32"
 
 # digital ocean specific vars for authentication to DO APIs and Storage
 do_token            = "changeme3"

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -192,16 +192,17 @@ Edit the vars file (gcp.tfvars) to customize the deployment, especially:
 # a public SSH key for SSH access to the instance via user `ubuntu`.
 # cat ~/.ssh/id_rsa.pub
 
-# mgmt_cidr
-# an IP range granted webUI and SSH access (without VPN). Also permitted PiHole DNS if dns_novpn = 1. 
-# deploying from home? This should be your public IP address with a /32 suffix. 
-
 # gcp_billing_account
 # The billing ID for the google cloud account
 
 # gcp_user
 # The GCP user
 ```
+
+>**Note**: Modify `mgmt_cidr` only if you must allow access to the deployed resources from a machine that is **not** the machine that is deploying this code *OR* if you must allow-list IPv6.
+# mgmt_cidr
+# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
+# deploying from home? This should be your public IP address with a /32 suffix. 
 
 # Post-Deployment
 - See terraform output for VPN Client configuration files link and the Pihole WebUI address.
@@ -226,9 +227,6 @@ wsl
 
 # Change to the project directory
 cd ~/cloudblock/gcp/
-
-# Update the mgmt_cidr variable - be sure to replace change_me with your public IP address
-sed -i -e "s#^mgmt_cidr = .*#mgmt_cidr = \"change_me/32\"#" gcp.tfvars
 
 # Rerun terraform apply, terraform will update the cloud firewall rules
 terraform apply -var-file="gcp.tfvars"

--- a/gcp/gcp-generic.tf
+++ b/gcp/gcp-generic.tf
@@ -154,3 +154,9 @@ variable "vpn_traffic" {
   type        = string
   description = "dns or all, sets the Wireguard VPN client configuration to route only dns traffic or all traffic through the VPN."
 }
+
+# IPv4 address for the machine executing the TF code
+
+data "http" "execution_ip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/gcp/gcp.tfvars
+++ b/gcp/gcp.tfvars
@@ -1,7 +1,9 @@
 ## COMMON ##
 ph_password = "changeme"
 ssh_key     = "ssh-rsa AAAAB3replace_me_replace_me_replace_me"
-mgmt_cidr   = "1.2.3.4/32"
+
+# This default value is set to IPv4 address of the machine executing the TF code. If you have other needs, such as different IPs between the machine executing TF code and the location that will use the pihole, then you must manually override this declaration
+mgmt_cidr = "${chomp(data.http.execution_ip.request_body)}/32"
 
 gcp_billing_account = "X1X1X1-ABABAB-123456"
 gcp_user            = "me@example.com"

--- a/lightsail/README.md
+++ b/lightsail/README.md
@@ -171,13 +171,16 @@ Edit the vars file (aws.tfvars) to customize the deployment, especially:
 # a public SSH key for SSH access to the instance via user `ubuntu`.
 # cat ~/.ssh/id_rsa.pub
 
-# mgmt_cidr
-# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
-# deploying from home? This should be your public IP address with a /32 suffix.
-
 # kms_manager
 # The AWS username (not root) granted access to read the Wireguard VPN configuration files in S3.
 ```
+
+>**Note**: Modify `mgmt_cidr` only if you must allow access to the deployed resources from a machine that is **not** the machine that is deploying this code *OR* if you must allow-list IPv6.
+```
+# mgmt_cidr
+# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
+# deploying from home? This should be your public IP address with a /32 suffix.
+``` 
 
 # Post-Deployment
 - Wait for Ansible Playbook, watch [AWS State Manager](https://console.aws.amazon.com/systems-manager/state-manager)
@@ -203,9 +206,6 @@ wsl
 
 # Change to the project directory
 cd ~/cloudblock/lightsail/
-
-# Update the mgmt_cidr variable - be sure to replace change_me with your public IP address
-sed -i -e "s#^mgmt_cidr = .*#mgmt_cidr = \"change_me/32\"#" aws.tfvars
 
 # Rerun terraform apply, terraform will update the cloud firewall rules
 terraform apply -var-file="aws.tfvars"

--- a/lightsail/aws-generic.tf
+++ b/lightsail/aws-generic.tf
@@ -136,3 +136,9 @@ variable "vpn_traffic" {
   type        = string
   description = "dns or all, sets the Wireguard VPN client configuration to route only dns traffic or all traffic through the VPN."
 }
+
+# IPv4 address for the machine executing the TF code
+
+data "http" "execution_ip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/lightsail/aws.tfvars
+++ b/lightsail/aws.tfvars
@@ -4,7 +4,8 @@ instance_key    = "ssh-rsa AAAAB3NzaC1ychange_me_change_me_change_me="
 
 # ip range permitted access to instance SSH and pihole webUI. Also granted DNS access if dns_novpn = 1.
 # Deploying for home use? This should be your public IP address/32.
-mgmt_cidr = "a.b.c.d/32"
+# This default value is set to IPv4 address of the machine executing the TF code. If you have other needs, such as different IPs between the machine executing TF code and the location that will use the pihole, then you must manually override this declaration
+mgmt_cidr = "${chomp(data.http.execution_ip.request_body)}/32"
 
 # an AWS IAM account (not root) performing the terraform apply. Granted access to s3 files, etc.
 kms_manager = "some_username"

--- a/oci/README.md
+++ b/oci/README.md
@@ -181,11 +181,7 @@ Edit the vars file (oci.tfvars) to customize the deployment, especially:
 
 # ssh_key
 # A public SSH key for access to the compute instance via SSH, with user ubuntu.
-# cat ~/.ssh/id_rsa.pub
-
-# mgmt_cidr
-# an IP range granted webUI, instance SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
-# deploying from home? This should be your public IP address with a /32 suffix.
+# cat ~/.ssh/id_rsa.pub 
 
 # oci_config_profile
 # The location of the oci config file (created by `oci setup config`)
@@ -197,6 +193,12 @@ Edit the vars file (oci.tfvars) to customize the deployment, especially:
 # See https://docs.cloud.oracle.com/en-us/iaas/images/ubuntu-2204/
 # Find Canonical-Ubuntu-18.04-Minimal, click it then use the OCID of the image in your region
 ```
+>**Note**: Modify `mgmt_cidr` only if you must allow access to the deployed resources from a machine that is **not** the machine that is deploying this code *OR* if you must allow-list IPv6.
+```
+# mgmt_cidr
+# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
+# deploying from home? This should be your public IP address with a /32 suffix.
+``` 
 
 # Post-Deployment
 - See terraform output for VPN Client configuration files link and the Pihole WebUI address.
@@ -221,9 +223,6 @@ wsl
 
 # Change to the project directory
 cd ~/cloudblock/oci/
-
-# Update the mgmt_cidr variable - be sure to replace change_me with your public IP address
-sed -i -e "s#^mgmt_cidr = .*#mgmt_cidr = \"change_me/32\"#" oci.tfvars
 
 # Rerun terraform apply, terraform will update the cloud firewall rules
 terraform apply -var-file="oci.tfvars"

--- a/oci/oci-generic.tf
+++ b/oci/oci-generic.tf
@@ -151,3 +151,9 @@ variable "vpn_traffic" {
   type        = string
   description = "dns or all, sets the Wireguard VPN client configuration to route only dns traffic or all traffic through the VPN."
 }
+
+# IPv4 address for the machine executing the TF code
+
+data "http" "execution_ip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/oci/oci.tfvars
+++ b/oci/oci.tfvars
@@ -1,7 +1,9 @@
 ## COMMON ##
 ph_password = "changeme"
 ssh_key     = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCNCHANGE_ME_CHANGE_ME_CHANGE_ME"
-mgmt_cidr   = "1.2.3.4/32"
+
+# This default value is set to IPv4 address of the machine executing the TF code. If you have other needs, such as different IPs between the machine executing TF code and the location that will use the pihole, then you must manually override this declaration
+mgmt_cidr = "${chomp(data.http.execution_ip.request_body)}/32"
 
 oci_config_profile   = "/home/chad/.oci/config"
 oci_root_compartment = "ocid1.tenancy.oc1..aaaaaaaaCHANGE_ME_CHANGE_ME_CHANGE_ME"

--- a/scw/README.md
+++ b/scw/README.md
@@ -164,16 +164,19 @@ Edit the vars file (scw.tfvars) to customize the deployment, especially:
 # A public SSH key for access to the compute instance via SSH, with user ubuntu.
 # cat ~/.ssh/id_rsa.pub
 
-# mgmt_cidr
-# an IP range granted webUI, instance SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
-# deploying from home? This should be your public IP address with a /32 suffix. 
-
 # scw_accesskey
 # The scaleway access key, used by nextcloud to talk with scaleway's object storage (username)
 
 # scw_secretkey
 # The scaleway secret key, used by nextcloud to talk with scaleway's object storage (password)
 ```
+
+>**Note**: Modify `mgmt_cidr` only if you must allow access to the deployed resources from a machine that is **not** the machine that is deploying this code *OR* if you must allow-list IPv6.
+```
+# mgmt_cidr
+# an IP range granted webUI, EC2 SSH access. Also permitted PiHole DNS if dns_novpn = 1 (default).
+# deploying from home? This should be your public IP address with a /32 suffix.
+``` 
 
 # Post-Deployment
 - See terraform output for VPN Client configuration files link and the Pihole WebUI address.
@@ -201,9 +204,6 @@ cd ~/cloudblock/scw/
 
 # Update the mgmt_cidr variable - be sure to replace change_me with your public IP address
 sed -i -e "s#^mgmt_cidr = .*#mgmt_cidr = \"change_me/32\"#" scw.tfvars
-
-# Rerun terraform apply, terraform will update the cloud firewall rules
-terraform apply -var-file="scw.tfvars"
 
 # If permissions errors appear, fix with the below command and re-run the terraform apply.
 sudo chown $USER scw.tfvars && chmod 600 scw.tfvars

--- a/scw/scw-generic.tf
+++ b/scw/scw-generic.tf
@@ -142,3 +142,9 @@ variable "dns_novpn" {
   type        = number
   description = "Enable (1) or disable (0) exposuring of port 53 (tcp and udp), DNS via pihole, to mgmt_cidr"
 }
+
+# IPv4 address for the machine executing the TF code
+
+data "http" "execution_ip" {
+  url = "http://ipv4.icanhazip.com"
+}

--- a/scw/scw.tfvars
+++ b/scw/scw.tfvars
@@ -1,7 +1,9 @@
 ## COMMON ##
 ph_password = "changeme1"
 ssh_key     = "ssh-rsa AAAAB3replace_me_replace_me_replace_me"
-mgmt_cidr   = "1.2.3.4/32"
+
+# This default value is set to IPv4 address of the machine executing the TF code. If you have other needs, such as different IPs between the machine executing TF code and the location that will use the pihole, then you must manually override this declaration
+mgmt_cidr = "${chomp(data.http.execution_ip.request_body)}/32"
 
 scw_accesskey = "changeme2"
 scw_secretkey = "changeme3"


### PR DESCRIPTION
**Summary:**

This PR enables the capability for the local machine's IPv4 address to be automatically captured and set within the firewall rules across all projects. The core functionality that allows this capability is usage of Terraform's [http data resource](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http), the [chomp function](https://developer.hashicorp.com/terraform/language/functions/chomp) and a [locals](https://developer.hashicorp.com/terraform/language/values/locals) block.

**Testing:**

Tested this with a [simple example here](https://gist.github.com/rbell23/e6654af6fd8eb3cf2a8cc77860f634e5). Output from that run is shown below.

![CleanShot 2023-09-23 at 17 23 44@2x](https://github.com/chadgeary/cloudblock/assets/106085657/727ae020-2898-4c40-bcce-714e63260f49)
